### PR TITLE
Fixed a small typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ Given a BPM of `90` and a `notesPerBeat` of `4` your `beatLength` in seconds sho
 
 #### Hints
 
-Since the Web Audio Clock is given in second-resolution, converting from BPM to BPS will make it easier to work with. You can do that by dividing the BPM value by 60 to make it Beats per Second insead.
+Since the Web Audio Clock is given in second-resolution, converting from BPM to BPS will make it easier to work with. You can do that by dividing the BPM value by 60 to make it Beats per Second instead.
 
 To find the beat number given total time and the length of a beat you can do `Math.floor(t / beatLength)`.
 


### PR DESCRIPTION
"insead" was typed where "instead" was meant

:wave: @mollerse 

I attended your Booster Conf workshop and I thoroughly enjoyed myself.

The README was an excellent guide and allowed me to create a step-sequencer and learn about the WebAudio API!

I would like to thank you for the time and effort you put in to the workshop. As a token of appreciation I submit this pull-request with a small typo fix.

I am looking forward to other workshops you might plan